### PR TITLE
[US327 Task328] Update metric wiki

### DIFF
--- a/react-ui/src/metricwiki/metricwiki.js
+++ b/react-ui/src/metricwiki/metricwiki.js
@@ -98,6 +98,9 @@ const MetricWiki = () => {
                             (ii) An Area Chart for the Partial Story Points (story points of completed tasks). <br/>
                             (iii) An Area Chart for the Business Value (for Business Value of completed user stories). <br/>
                             (iv) An Area Chart combining all of the three metrics taken as a percentage of their total. <br/>
+                            (v) A day-wise Multi-sprint Story Point Comparison between the selected sprints. <br/>
+                            (vi) A day-wise Multi-sprint Business Value Comparison between the selected sprints. <br/>
+                            (vii) A Multi-sprint Bar Chart showing the total business value and story points for each sprint. <br/>
                             <br/><br/>
                         </div>
                         <div id="DevFocusInfo">


### PR DESCRIPTION
Updated the burndown wiki page to include info about multi sprints.
![image](https://github.com/SER516-Clever/SER516-Team-Clever/assets/143535096/656ac583-8c14-4187-b9ac-5bbee95224e0)
